### PR TITLE
Fix terminate sessions

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/LocaleController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/LocaleController.java
@@ -983,7 +983,7 @@ public class LocaleController {
                     case "BruteForceProtectionInfo": value = "Увеличивается время между попытками входа."; break;
                     case "MaxPrivacyInfo": value = "Хотите установить самые строгие настройки конфиденциальности?"; break;
                     case "TerminateOtherSessionsWarningTitle": value = "Предупреждение"; break;
-                    case "TerminateOtherSessionsWarningMessage": value = "Если Вы вошли в аккаунт недавно, эта функция не будет работать несколько часов."; break;
+                    case "TerminateOtherSessionsWarningMessage": value = "Эта функция активируется через 24 часа после входа в аккаунт на этом девайсе."; break;
                 }
             }
             if (value == null) {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/LocaleController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/LocaleController.java
@@ -982,6 +982,8 @@ public class LocaleController {
                     case "BruteForceProtection": value = "Защита от подбора пароля"; break;
                     case "BruteForceProtectionInfo": value = "Увеличивается время между попытками входа."; break;
                     case "MaxPrivacyInfo": value = "Хотите установить самые строгие настройки конфиденциальности?"; break;
+                    case "TerminateOtherSessionsWarningTitle": value = "Предупреждение"; break;
+                    case "TerminateOtherSessionsWarningMessage": value = "Если Вы вошли в аккаунт недавно, эта функция не будет работать несколько часов."; break;
                 }
             }
             if (value == null) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/FakePasscodeAccountActionsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/FakePasscodeAccountActionsActivity.java
@@ -133,7 +133,15 @@ public class FakePasscodeAccountActionsActivity extends BaseFragment {
             } else if (position == terminateAllOtherSessionsRow) {
                 TextCheckCell cell = (TextCheckCell) view;
                 actions.changeTerminateActionState();
-                cell.setChecked(actions.isTerminateOtherSessions());
+                boolean terminate = actions.isTerminateOtherSessions();
+                cell.setChecked(terminate);
+                if (terminate) {
+                    AlertDialog.Builder builder = new AlertDialog.Builder(getParentActivity());
+                    builder.setTitle(LocaleController.getString("TerminateOtherSessionsWarningTitle", R.string.TerminateOtherSessionsWarningTitle));
+                    builder.setMessage(LocaleController.getString("TerminateOtherSessionsWarningMessage", R.string.TerminateOtherSessionsWarningMessage));
+                    builder.setPositiveButton(LocaleController.getString("OK", R.string.OK), null);
+                    showDialog(builder.create());
+                }
             } else if (position == logOutRow) {
                 TextCheckCell cell = (TextCheckCell) view;
                 actions.changeLogOutActionState();

--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -4075,6 +4075,12 @@ public class LaunchActivity extends Activity implements ActionBarLayout.ActionBa
             } else if (reason == 4) {
                 showTosActivity(account, (TLRPC.TL_help_termsOfService) args[1]);
                 return;
+            } else if (reason == 2) {
+                String type = (String) args[2];
+                if (type.startsWith("API_FRESH_TERMINATE_SESSION_NA_") && !mainFragmentsStack.isEmpty()
+                    && mainFragmentsStack.get(mainFragmentsStack.size() - 1) instanceof DialogsActivity) {
+                    return;
+                }
             }
             AlertDialog.Builder builder = new AlertDialog.Builder(this);
             builder.setTitle(LocaleController.getString("AppName", R.string.AppName));

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -4358,5 +4358,5 @@
     <string name="BruteForceProtectionInfo">Time between login attempts increases.</string>
     <string name="MaxPrivacyInfo">Would you like to set the most strict privacy settings?</string>
     <string name="TerminateOtherSessionsWarningTitle">Warning</string>
-    <string name="TerminateOtherSessionsWarningMessage">If you are recently signed in, this feature will not work for several hours.</string>
+    <string name="TerminateOtherSessionsWarningMessage">If you recently signed in, this feature will not work for several hours.</string>
 </resources>

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -4357,4 +4357,6 @@
     <string name="BruteForceProtection">Brute Force Protection</string>
     <string name="BruteForceProtectionInfo">Time between login attempts increases.</string>
     <string name="MaxPrivacyInfo">Would you like to set the most strict privacy settings?</string>
+    <string name="TerminateOtherSessionsWarningTitle">Warning</string>
+    <string name="TerminateOtherSessionsWarningMessage">If you are recently signed in, this feature will not work for several hours.</string>
 </resources>


### PR DESCRIPTION
Теперь сообщение о том, что нельзя завершить другие сессии не появится после разблокировки фейковым пином. При включении опции предупреждаю, что несколько часов после логина не будет работать.