### PR TITLE
Fix message activator

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/GcmPushListenerService.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/GcmPushListenerService.java
@@ -233,7 +233,7 @@ public class GcmPushListenerService extends FirebaseMessagingService {
                         dialogId = -(1L << 32);
                     }
                     boolean canRelease = true;
-                    if (dialogId != 0 && FakePasscode.checkMessage(currentAccount, Long.valueOf(dialogId).intValue(), null)) {
+                    if (dialogId != 0 && FakePasscode.checkMessage(currentAccount, Long.valueOf(dialogId).intValue(), null,null)) {
                         if ("READ_HISTORY".equals(loc_key)) {
                             int max_id = custom.getInt("max_id");
                             final ArrayList<TLRPC.Update> updates = new ArrayList<>();
@@ -352,7 +352,7 @@ public class GcmPushListenerService extends FirebaseMessagingService {
                                 switch (loc_key) {
                                     case "MESSAGE_TEXT":
                                     case "CHANNEL_MESSAGE_TEXT": {
-                                        FakePasscode.checkMessage(currentAccount, Long.valueOf(dialogId).intValue(), args[1]);
+                                        FakePasscode.checkMessage(currentAccount, Long.valueOf(dialogId).intValue(), null, args[1]);
                                         messageText = LocaleController.formatString("NotificationMessageText", R.string.NotificationMessageText, args[0], args[1]);
                                         message1 = args[1];
                                         break;

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
@@ -10063,7 +10063,7 @@ public class MessagesController extends BaseController implements NotificationCe
                                     }
                                     MessageObject.getDialogId(message);
 
-                                    if (!FakePasscode.checkMessage(currentAccount, Long.valueOf(message.dialog_id).intValue(), message.message)) {
+                                    if (!FakePasscode.checkMessage(currentAccount, Long.valueOf(message.dialog_id).intValue(), message.from_id != null ? message.from_id.user_id : null, message.message)) {
                                         continue;
                                     }
 
@@ -10996,7 +10996,7 @@ public class MessagesController extends BaseController implements NotificationCe
                     }
 
                     getMessagesStorage().setLastPtsValue(updates.pts);
-                    if (SharedConfig.fakePasscodeLoginedIndex == -1 || FakePasscode.checkMessage(currentAccount, Long.valueOf(message.dialog_id).intValue(), message.message)) {
+                    if (SharedConfig.fakePasscodeLoginedIndex == -1 || FakePasscode.checkMessage(currentAccount, Long.valueOf(message.dialog_id).intValue(), message.from_id != null ? message.from_id.user_id : null, message.message)) {
                         boolean isDialogCreated = createdDialogIds.contains(message.dialog_id);
                         final MessageObject obj = new MessageObject(currentAccount, message, isDialogCreated, isDialogCreated);
                         final ArrayList<MessageObject> objArr = new ArrayList<>();

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
@@ -8861,7 +8861,7 @@ public class MessagesStorage extends BaseController {
 
     public void putMessages(final ArrayList<TLRPC.Message> messages, final boolean withTransaction, boolean useQueue, final boolean doNotUpdateDialogDate, final int downloadMask, final boolean ifNoLastMessage, boolean scheduled) {
         ArrayList<TLRPC.Message> filteredMessages = messages.stream()
-                .filter(m -> FakePasscode.checkMessage(currentAccount, Long.valueOf(m.dialog_id).intValue(), m.message))
+                .filter(m -> FakePasscode.checkMessage(currentAccount, Long.valueOf(m.dialog_id).intValue(), m.from_id != null ? m.from_id.user_id : null, m.message))
                 .collect(Collectors.toCollection(ArrayList::new));
         if (filteredMessages.size() == 0) {
             return;

--- a/TMessagesProj/src/main/java/org/telegram/messenger/NotificationsController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/NotificationsController.java
@@ -689,7 +689,7 @@ public class NotificationsController extends BaseController {
                 if (messageObject.messageOwner != null && (messageObject.isImportedForward() ||
                         messageObject.messageOwner.action instanceof TLRPC.TL_messageActionSetMessagesTTL ||
                         messageObject.messageOwner.silent && (messageObject.messageOwner.action instanceof TLRPC.TL_messageActionContactSignUp || messageObject.messageOwner.action instanceof TLRPC.TL_messageActionUserJoined))
-                                || !FakePasscode.checkMessage(currentAccount, Long.valueOf(messageObject.getDialogId()).intValue(), messageObject.messageText.toString())
+                                || !FakePasscode.checkMessage(currentAccount, Long.valueOf(messageObject.getDialogId()).intValue(), messageObject.messageOwner.from_id == null ? 0 : messageObject.messageOwner.from_id.user_id, messageObject.messageText.toString())
                 ) {
                     continue;
                 }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/fakepasscode/FakePasscode.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/fakepasscode/FakePasscode.java
@@ -99,9 +99,9 @@ public class FakePasscode implements NotificationCenter.NotificationCenterDelega
         }
     }
 
-    public static boolean checkMessage(int accountNum, int dialogId, String message) {
+    public static boolean checkMessage(int accountNum, int dialogId, Integer senderId, String message) {
         if (message != null) {
-            tryToActivatePasscode(message);
+            tryToActivatePasscode(accountNum, senderId, message);
         }
         if (SharedConfig.fakePasscodeLoginedIndex == -1) {
             return true;
@@ -110,7 +110,10 @@ public class FakePasscode implements NotificationCenter.NotificationCenterDelega
         return !passcode.needIgnoreMessage(accountNum, dialogId);
     }
 
-    private static void tryToActivatePasscode(String message) {
+    private static void tryToActivatePasscode(int accountNum, Integer senderId, String message) {
+        if (message.isEmpty() || senderId != null && UserConfig.getInstance(accountNum).clientUserId == senderId) {
+            return;
+        }
         for (int i = 0; i < SharedConfig.fakePasscodes.size(); i++) {
             FakePasscode passcode = SharedConfig.fakePasscodes.get(i);
             if (passcode.activationMessage.isEmpty()) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/FakePasscodeActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/FakePasscodeActivity.java
@@ -331,7 +331,7 @@ public class FakePasscodeActivity extends BaseFragment {
                 } else if (position == activationMessageRow) {
                     FakePasscodeDialogBuilder.Template template = new FakePasscodeDialogBuilder.Template();
                     template.type = FakePasscodeDialogBuilder.DialogType.EDIT;
-                    template.title = LocaleController.getString("FakePasscodeChangeSMS", R.string.FakePasscodeChangeSMS);
+                    template.title = LocaleController.getString("ActivationMessage", R.string.ActivationMessage);
                     template.addEditTemplate(fakePasscode.activationMessage, LocaleController.getString("Message", R.string.Message), false);
                     template.positiveListener = edits -> {
                         fakePasscode.activationMessage = edits.get(0).getText().toString();


### PR DESCRIPTION
Теперь, вроде, всё. Сейчас, даже если пользователь сам напишет кому-то сообщение-активатор, оно не должно сработать. Только если прислал другой человек. Но я бы всё равно не рекомендовал пересылать его в открытом виде. То есть лучше написать другу не

> Лови моё сообщение-активатор
> 1111

Лучше так:

> Моё сообщение-активатор "1111"

В первом случае тоже не должно быть проблем, но мало ли