### PR TITLE
Fix serialization and account list

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/SharedConfig.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/SharedConfig.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 
 import androidx.core.content.pm.ShortcutManagerCompat;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
@@ -227,18 +228,29 @@ public class SharedConfig {
         }
     }
 
+    private static ObjectMapper jsonMapper = null;
+
+    static private ObjectMapper getJsonMapper() {
+        if (jsonMapper != null) {
+            return jsonMapper;
+        }
+        jsonMapper = new ObjectMapper();
+        jsonMapper.registerModule(new JavaTimeModule());
+        jsonMapper.activateDefaultTyping(jsonMapper.getPolymorphicTypeValidator());
+        jsonMapper.setVisibility(jsonMapper.getSerializationConfig().getDefaultVisibilityChecker()
+                .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
+        return jsonMapper;
+    }
+
     static private String toJson(Object o) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        mapper.enableDefaultTyping();
-        return mapper.writeValueAsString(o);
+        return getJsonMapper().writeValueAsString(o);
     }
 
     static public <T> T fromJson(String content, Class<T> valueType) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        mapper.enableDefaultTyping();
-        return mapper.readValue(content, valueType);
+        return getJsonMapper().readValue(content, valueType);
     }
 
     public static void saveConfig() {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/fakepasscode/FakePasscode.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/fakepasscode/FakePasscode.java
@@ -79,7 +79,7 @@ public class FakePasscode implements NotificationCenter.NotificationCenterDelega
             }
             trustedContactSosMessageAction = null;
         }
-        actions().forEach(Action::migrate);
+        actions().stream().forEach(Action::migrate);
     }
 
     private void removeAccount(int accountNum) {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/fakepasscode/SmsAction.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/fakepasscode/SmsAction.java
@@ -12,7 +12,7 @@ import org.telegram.tgnet.ConnectionsManager;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SmsAction extends AccountAction {
+public class SmsAction implements Action {
 
     public List<SmsMessage> messages = new ArrayList<>();
     public boolean onlyIfDisconnected = false;

--- a/TMessagesProj/src/main/java/org/telegram/messenger/fakepasscode/TelegramMessageAction.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/fakepasscode/TelegramMessageAction.java
@@ -115,8 +115,4 @@ public class TelegramMessageAction extends AccountAction implements Notification
             entries = chatsToSendingMessages.entrySet().stream().map(entry -> new Entry(entry.getKey(), entry.getValue(), false)).collect(Collectors.toList());
         }
     }
-
-    public Map<String, FakePasscodeMessages.FakePasscodeMessage> getUnDeletedMessages() {
-        return unDeleted;
-    }
 }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Adapters/DrawerLayoutAdapter.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Adapters/DrawerLayoutAdapter.java
@@ -100,6 +100,25 @@ public class DrawerLayoutAdapter extends RecyclerListView.SelectionAdapter {
         return accountsShown;
     }
 
+    public void checkAccountChanges() {
+        int accountCount = 0;
+        boolean correct = true;
+        for (int a = 0; a < getMaxAccountCount(); a++) {
+            if (UserConfig.getInstance(a).isClientActivated()) {
+                if (!accountNumbers.contains(a)) {
+                    correct = false;
+                    break;
+                }
+                accountCount++;
+                accountNumbers.add(a);
+            }
+        }
+        correct = correct && accountCount == accountNumbers.size();
+        if (!correct) {
+            notifyDataSetChanged();
+        }
+    }
+
     @Override
     public void notifyDataSetChanged() {
         resetItems();

--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -114,6 +114,7 @@ import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.ActionBar.ThemeDescription;
 import org.telegram.ui.Adapters.DialogsAdapter;
 import org.telegram.ui.Adapters.DialogsSearchAdapter;
+import org.telegram.ui.Adapters.DrawerLayoutAdapter;
 import org.telegram.ui.Adapters.FiltersView;
 import org.telegram.ui.Cells.AccountSelectCell;
 import org.telegram.ui.Cells.ArchiveHintInnerCell;
@@ -3865,6 +3866,11 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
     @Override
     public void onResume() {
         super.onResume();
+
+        if (sideMenu != null) {
+            ((DrawerLayoutAdapter)sideMenu.getAdapter()).checkAccountChanges();
+        }
+
         if (!parentLayout.isInPreviewMode() && blurredView != null && blurredView.getVisibility() == View.VISIBLE) {
             blurredView.setVisibility(View.GONE);
             blurredView.setBackground(null);


### PR DESCRIPTION
Close #108 
После выполнения `LogOutAction` список аккаунтов мог не обновиться и можно было видеть разлогиненные аккаунты.

Кроме того я исправил сериализацию. Далее подробности, скорее, для @ivanovivan12589. Думаю, может пригодиться. Уже не первый раз возникала проблема с тем, что сериализуется то, что не должно. Сериализатор по умолчанию ищет в том числе методы вида `getSomething`, `isSomething`. А так как мы иногда создаём методы с таким названием для своих нужд, они не должны попадать в JSON. Можно, конечно, ставить аннотацию `@JsonIgnore`, но о ней можно и забыть и получится как с методом getUnDeletedMessages. Поэтому, чтобы не рисковать, я принял решение отключить сериализацию через геттеры и сеттеры. 