### PR TITLE
Fix multiple delete requests

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
@@ -2082,7 +2082,7 @@ public class DialogCell extends BaseCell {
                     }
                 }
                 if (!continueUpdate && (mask & MessagesController.UPDATE_MASK_READ_DIALOG_MESSAGE) != 0) {
-                    if (message != null && !message.isUnread()) {
+                    if (message != null && !message.isUnread() && lastUnreadState != message.isUnread()) {
                         List<MessageObject> messages = new ArrayList<>();
                         messages.add(message);
                         Utils.startDeleteProcess(currentAccount, currentDialogId, messages);


### PR DESCRIPTION
При работающем приложении, при использовании автоудаляемых сообщений, в `DialogCell` более одного раза добавлялась задача на удаление сообщения. Пофиксил добавлением дополнительного условия