### PR TITLE
Fix abs dialog ids

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
@@ -14814,7 +14814,7 @@ public class MessagesController extends BaseController implements NotificationCe
         }
 
         if (!messagesIds.isEmpty()) {
-            deleteMessages(messagesIds, null, null, Math.abs(dialogId),
+            deleteMessages(messagesIds, null, null, dialogId,
                     true, false, false, 0,
                     null, false, false);
         }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/fakepasscode/Utils.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/fakepasscode/Utils.java
@@ -188,7 +188,7 @@ public class Utils {
             int delay = idToMs.getValue();
             Utilities.globalQueue.postRunnable(() -> {
                 AndroidUtilities.runOnUIThread(() -> {
-                    MessagesController.getInstance(currentAccount).deleteMessages(ids, null, null, Math.abs(currentDialogId),
+                    MessagesController.getInstance(currentAccount).deleteMessages(ids, null, null, currentDialogId,
                             true, false, false, 0,
                             null, false, false);
                     cleanAutoDeletable(ids.get(0), currentAccount, currentDialogId);

--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -908,7 +908,7 @@ public class LaunchActivity extends Activity implements ActionBarLayout.ActionBa
             long shift = System.currentTimeMillis() - idToMs.getValue().first.second;
             shift = idToMs.getValue().first.first - shift;
             Utilities.globalQueue.postRunnable(() -> {
-                MessagesController.getInstance(currentAccount).deleteMessages(ids, null, null, Math.abs(dialogId),
+                MessagesController.getInstance(currentAccount).deleteMessages(ids, null, null, dialogId,
                         true, false, false, 0,
                         null, false, false);
                 Utils.cleanAutoDeletable(ids.get(0), currentAccount, dialogId);


### PR DESCRIPTION
Заметил, что в группах, которые стали публичными, из-за модуля айди сообщения не удалялись. Убрал модуль, на эмуляторах стали удаляться